### PR TITLE
fix typo in comment in msgrpc

### DIFF
--- a/plugins/msgrpc.rb
+++ b/plugins/msgrpc.rb
@@ -31,7 +31,7 @@ class Plugin::MSGRPC < Msf::Plugin
   #
   # ServerPort
   #
-  # 	The local port to listen on for connections.  The default is 55553
+  # 	The local port to listen on for connections.  The default is 55552
   #
   def initialize(framework, opts)
     super


### PR DESCRIPTION
Fix a little typo in comment in msgrpc:

```
s/The default is 55553/The default is 55552
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

